### PR TITLE
Improve the parsing of datetime

### DIFF
--- a/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
+++ b/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
@@ -12,7 +12,9 @@ addCmd: task BY datetime                # addTask
 task:   .+?;
 /* Note: 10 Jan 11 will be understood as 10 Jan of the year 11
  * to specify 10 January, 11 o'lock, make 11 more explicit as a
- * tim e.g. 11.00, 11 a.m., etc.
+ * time e.g. 11.00, 11 a.m., etc.
+ * to specify 10 o'clock, 11 January, make 10 more explicit as a
+ * time
  */ 
 datetime:   date        # dateOnly
         |   time        # timeOnly

--- a/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
+++ b/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
@@ -17,13 +17,12 @@ datetime:   time date   # timeThenDate
         ;
 date:   TODAY                           # today
     |   TOMORROW                        # tomorrow
-    |   dayOfWeek                       # dayOfWeekOnly
-    |   THIS dayOfWeek                  # thisDayOfWeek
-    |   NEXT dayOfWeek                  # nextDayOfWeek
+    |   DAY_OF_WEEK                     # dayOfWeekOnly
+    |   THIS DAY_OF_WEEK                # thisDayOfWeek
+    |   NEXT DAY_OF_WEEK                # nextDayOfWeek
     |   INT ('/'|'-') INT ('/'|'-') INT # fullDate
     |   INT ('/'|'-') INT               # dayMonth
     ;
-dayOfWeek:  MON | TUE | WED | THU | FRI | SAT | SUN;
 time:   INT                         # hourOnly
     |   INT ('.'|':') INT           # hourMinute
     |   INT (AM|PM)                 # hourNoon
@@ -44,14 +43,14 @@ TOMORROW: [Tt][Oo][Mm][Oo][Rr][Rr][Oo][Ww];
 THIS: [Tt][Hh][Ii][Ss];
 NEXT: [Nn][Ee][Xx][Tt];
 
-MON: [Mm][Oo][Nn]([Dd][Aa][Yy])?;
-TUE: [Tt][Uu][Ee]([Ss][Dd][Aa][Yy])?;
-WED:[Ww][Ee][Dd]([Nn][Ee][Ss][Dd][Aa][Yy])?;
-THU: [Tt][Hh][Uu]([Rr][Ss][Dd][Aa][Yy])?;
-FRI: [Ff][Rr][Ii]([Dd][Aa][Yy])?;
-SAT: [Ss][Aa][Tt]([Uu][Rr][Dd][Aa][Yy])?;
-SUN: [Ss][Uu][Nn]([Dd][Aa][Yy])?;
-
+DAY_OF_WEEK:    [Mm][Oo][Nn]([Dd][Aa][Yy])?
+            |   [Tt][Uu][Ee]([Ss][Dd][Aa][Yy])?
+            |   [Ww][Ee][Dd]([Nn][Ee][Ss][Dd][Aa][Yy])?
+            |   [Tt][Hh][Uu]([Rr][Ss][Dd][Aa][Yy])?
+            |   [Ff][Rr][Ii]([Dd][Aa][Yy])?
+            |   [Ss][Aa][Tt]([Uu][Rr][Dd][Aa][Yy])?
+            |   [Ss][Uu][Nn]([Dd][Aa][Yy])?
+            ;
 INT:[0-9]+;
 
 WORD: [a-zA-Z0-9]+ ;

--- a/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
+++ b/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
@@ -1,32 +1,34 @@
 grammar UserCommand;
 
-cmd:	addCmd
-	;
+cmd:    addCmd
+    ;
 
-addCmd: task BY datetime				# addTask
-	|	task date FROM time TO time		# addEventCommonDate
-	|	task FROM datetime TO datetime	# addEvent
-	|	task							# addFloatingTask
-	;
+addCmd: task BY datetime                # addTask
+    |   task date FROM time TO time     # addEventCommonDate
+    |   task FROM datetime TO datetime  # addEvent
+    |   task                            # addFloatingTask
+    ;
 	
-task:	.+?;
-datetime: time date	# timeThenDate
-	| date time		# dateThenTime
-	| date			# dateOnly
-	| time			# timeOnly
-	;
-date:	TODAY							# today
-	|	TOMORROW						# tomorrow
-	|	dayOfWeek						# dayOfWeekOnly
-	|	THIS dayOfWeek					# thisDayOfWeek
-	|	NEXT dayOfWeek					# nextDayOfWeek
-	|	INT ('/'|'-') INT ('/'|'-') INT	# fullDate
-	|	INT ('/'|'-') INT				# dayMonth
-	;
-dayOfWeek:	MON | TUE | WED | THU | FRI | SAT | SUN;
-time:	INT					# hourOnly
-	|	INT ('.'|':') INT	# hourMinute
-	;
+task:   .+?;
+datetime:   time date   # timeThenDate
+        |   date time   # dateThenTime
+        |   date        # dateOnly
+        |   time        # timeOnly
+        ;
+date:   TODAY                           # today
+    |   TOMORROW                        # tomorrow
+    |   dayOfWeek                       # dayOfWeekOnly
+    |   THIS dayOfWeek                  # thisDayOfWeek
+    |   NEXT dayOfWeek                  # nextDayOfWeek
+    |   INT ('/'|'-') INT ('/'|'-') INT # fullDate
+    |   INT ('/'|'-') INT               # dayMonth
+    ;
+dayOfWeek:  MON | TUE | WED | THU | FRI | SAT | SUN;
+time:   INT                         # hourOnly
+    |   INT ('.'|':') INT           # hourMinute
+    |   INT (AM|PM)                 # hourNoon
+    |   INT ('.'|':') INT (AM|PM)   # hourMinuteNoon
+    ;
 
 
 BY:	[Bb][Yy];
@@ -34,20 +36,23 @@ FROM: [Ff][Rr][Oo][Mm];
 TO:	[Tt][Oo];
 AT: [Aa][Tt];
 
+AM: [Aa].?[Mm].?;
+PM: [Pp].?[Mm].?;
+
 TODAY: [Tt][Oo][Dd][Aa][Yy];
 TOMORROW: [Tt][Oo][Mm][Oo][Rr][Rr][Oo][Ww];
 THIS: [Tt][Hh][Ii][Ss];
 NEXT: [Nn][Ee][Xx][Tt];
 
-MON:	[Mm][Oo][Nn]([Dd][Aa][Yy])?;
-TUE:	[Tt][Uu][Ee]([Ss][Dd][Aa][Yy])?;
-WED:	[Ww][Ee][Dd]([Nn][Ee][Ss][Dd][Aa][Yy])?;
-THU:	[Tt][Hh][Uu]([Rr][Ss][Dd][Aa][Yy])?;
-FRI:	[Ff][Rr][Ii]([Dd][Aa][Yy])?;
-SAT:	[Ss][Aa][Tt]([Uu][Rr][Dd][Aa][Yy])?;
-SUN:	[Ss][Uu][Nn]([Dd][Aa][Yy])?;
+MON: [Mm][Oo][Nn]([Dd][Aa][Yy])?;
+TUE: [Tt][Uu][Ee]([Ss][Dd][Aa][Yy])?;
+WED:[Ww][Ee][Dd]([Nn][Ee][Ss][Dd][Aa][Yy])?;
+THU: [Tt][Hh][Uu]([Rr][Ss][Dd][Aa][Yy])?;
+FRI: [Ff][Rr][Ii]([Dd][Aa][Yy])?;
+SAT: [Ss][Aa][Tt]([Uu][Rr][Dd][Aa][Yy])?;
+SUN: [Ss][Uu][Nn]([Dd][Aa][Yy])?;
 
-INT:	[0-9]+;
+INT:[0-9]+;
 
-WORD:	[a-zA-Z0-9]+ ;
+WORD: [a-zA-Z0-9]+ ;
 WS: [ \t\r\n]+ -> skip;

--- a/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
+++ b/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
@@ -10,18 +10,26 @@ addCmd: task BY datetime                # addTask
     ;
 	
 task:   .+?;
-datetime:   time date   # timeThenDate
-        |   date time   # dateThenTime
-        |   date        # dateOnly
+/* Note: 10 Jan 11 will be understood as 10 Jan of the year 11
+ * to specify 10 January, 11 o'lock, make 11 more explicit as a
+ * tim e.g. 11.00, 11 a.m., etc.
+ */ 
+datetime:   date        # dateOnly
         |   time        # timeOnly
+        |   date time   # dateThenTime
+        |   time date   # timeThenDate
         ;
-date:   TODAY                           # today
-    |   TOMORROW                        # tomorrow
-    |   DAY_OF_WEEK                     # dayOfWeekOnly
-    |   THIS DAY_OF_WEEK                # thisDayOfWeek
-    |   NEXT DAY_OF_WEEK                # nextDayOfWeek
-    |   INT ('/'|'-') INT ('/'|'-') INT # fullDate
-    |   INT ('/'|'-') INT               # dayMonth
+date:   TODAY                               # today
+    |   TOMORROW                            # tomorrow
+    |   DAY_OF_WEEK                         # dayOfWeekOnly
+    |   THIS DAY_OF_WEEK                    # thisDayOfWeek
+    |   NEXT DAY_OF_WEEK                    # nextDayOfWeek
+    |   INT ('/'|'-') INT ('/'|'-') INT     # fullDate
+    |   INT ('/'|'-') INT                   # dayMonth
+    |   INT ('/'|'-'|',')? MONTH ('/'|'-'|',')? INT # fullDateWordMonth
+    |   INT ('/'|'-'|',')? MONTH                    # dayMonthWordMonth
+    |   MONTH ('/'|'-'|',')? INT ('/'|'-'|',')? INT # fullDateWordMonthMonthFirst
+    |   MONTH ('/'|'-'|',')? INT                    # dayMonthWordMonthMonthFirst
     ;
 time:   INT                         # hourOnly
     |   INT ('.'|':') INT           # hourMinute
@@ -51,6 +59,19 @@ DAY_OF_WEEK:    [Mm][Oo][Nn]([Dd][Aa][Yy])?
             |   [Ss][Aa][Tt]([Uu][Rr][Dd][Aa][Yy])?
             |   [Ss][Uu][Nn]([Dd][Aa][Yy])?
             ;
+MONTH:  [Jj][Aa][Nn]([Uu][Aa][Rr][Yy])?
+    |   [Ff][Ee][Bb]([Rr][Uu][Aa][Rr][Yy])?
+    |   [Mm][Aa][Rr]([Cc][Hh])?
+    |   [Aa][Pp][Rr]([Ii][Ll])?
+    |   [Mm][Aa][Yy]
+    |   [Jj][Uu][Nn]([Ee])?
+    |   [Jj][Uu][Ll]([Yy])?
+    |   [Aa][Uu][Gg]([Uu][Ss][Tt])?
+    |   [Ss][Ee][Pp]([Tt][Ee][Mm][Bb][Ee][Rr])?
+    |   [Oo][Cc][Tt]([Oo][Bb][Ee][Rr])?
+    |   [Nn][Oo][Vv]([Ee][Mm][Bb][Ee][Rr])?
+    |   [Dd][Ee][Cc]([Ee][Mm][Bb][Ee][Rr])?
+    ;
 INT:[0-9]+;
 
 WORD: [a-zA-Z0-9]+ ;

--- a/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
+++ b/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
@@ -1,5 +1,6 @@
 package cs2103.v15_1j.jimjim;
 
+import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -158,7 +159,41 @@ public class JJCommandVisitor extends UserCommandBaseVisitor<Command> {
 		visit(ctx.time());
 		dateTimeMap.put(ctx, LocalDateTime.of(dateMap.get(ctx.date()),
 											  timeMap.get(ctx.time())));
-		return null;	}
+		return null;
+	}
 
+    @Override
+    public Command visitHourNoon(UserCommandParser.HourNoonContext ctx) {
+        int hour = Integer.parseInt(ctx.INT().getText());
+        hour = process12Hour(hour, ctx.AM() == null);
+        timeMap.put(ctx, LocalTime.of(hour, 0));        
+        return null;
+    }
+    
+    @Override
+    public Command visitHourMinuteNoon(UserCommandParser.HourMinuteNoonContext ctx) {
+        int hour = Integer.parseInt(ctx.INT(0).getText());
+        hour = process12Hour(hour, ctx.AM() == null);
+        int minute = Integer.parseInt(ctx.INT(1).getText());
+        timeMap.put(ctx, LocalTime.of(hour, minute));        
+        return null;
+    }
+    
+    private int process12Hour(int hour, boolean isPm) {
+        if ((hour > 12) || (hour <= 0)) {
+            throw new DateTimeException(
+                    "Invalid time, please use correct 12-hour format: " + hour);
+        }
+        int offset = isPm ? 12 : 0;
+        hour += offset;
+        if (hour == 12) {   // those are corner cases
+            // 12am
+            hour = 0;
+        } else if (hour == 24) {
+            // 12pm
+            hour = 12;
+        }
+        return hour;
+    }
 
 }

--- a/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
+++ b/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import org.antlr.v4.runtime.tree.ParseTreeProperty;
+import org.antlr.v4.runtime.tree.TerminalNode;
 
 import cs2103.v15_1j.jimjim.antlr4.UserCommandBaseVisitor;
 import cs2103.v15_1j.jimjim.antlr4.UserCommandParser;
@@ -196,4 +197,55 @@ public class JJCommandVisitor extends UserCommandBaseVisitor<Command> {
         return hour;
     }
 
+	@Override
+	public Command visitFullDateWordMonth(
+	        UserCommandParser.FullDateWordMonthContext ctx) {
+		int day = Integer.parseInt(ctx.INT(0).getText());
+		int month = getMonth(ctx.MONTH());
+		int year = Integer.parseInt(ctx.INT(1).getText());
+		dateMap.put(ctx, LocalDate.of(year, month, day));
+		return null;
+    }
+
+	@Override
+	public Command visitDayMonthWordMonth(
+	        UserCommandParser.DayMonthWordMonthContext ctx) {
+		int year = LocalDate.now().getYear();
+		int month = getMonth(ctx.MONTH());
+		int day = Integer.parseInt(ctx.INT().getText());
+		dateMap.put(ctx, LocalDate.of(year, month, day));
+		return null;
+    }
+
+	@Override
+	public Command visitFullDateWordMonthMonthFirst(
+	        UserCommandParser.FullDateWordMonthMonthFirstContext ctx) {
+		int day = Integer.parseInt(ctx.INT(0).getText());
+		int month = getMonth(ctx.MONTH());
+		int year = Integer.parseInt(ctx.INT(1).getText());
+		dateMap.put(ctx, LocalDate.of(year, month, day));
+		return null;
+    }
+
+	@Override
+	public Command visitDayMonthWordMonthMonthFirst(
+	        UserCommandParser.DayMonthWordMonthMonthFirstContext ctx) {
+		int year = LocalDate.now().getYear();
+		int month = getMonth(ctx.MONTH());
+		int day = Integer.parseInt(ctx.INT().getText());
+		dateMap.put(ctx, LocalDate.of(year, month, day));
+		return null;
+    }
+	
+	private int getMonth(TerminalNode terminalNode) {
+		String month = terminalNode.getText().substring(0, 3).toLowerCase();
+		String[] months = {"", "jan", "feb", "mar", "apr", "may", "jun", "jul",
+		        "aug", "sep", "oct", "nov", "dec"};
+		for (int i=0; i<months.length; i++) {
+			if (months[i].equals(month)) {
+				return i;
+			}
+		}
+		return 0;	// shouldn't happen
+	}
 }

--- a/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
+++ b/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
@@ -87,7 +87,7 @@ public class JJCommandVisitor extends UserCommandBaseVisitor<Command> {
 		return null;
 	}
 	
-	private int getDayOfWeekInt(UserCommandParser.DayOfWeekContext ctx) {
+	private int getDayOfWeekInt(UserCommandParser.DayOfWeekOnlyContext ctx) {
 		String day = ctx.getText().substring(0, 3).toLowerCase();
 		String[] days = {"", "mon", "tue", "wed", "thu", "fri", "sat", "sun"};
 		for (int i=0; i<days.length; i++) {
@@ -100,7 +100,7 @@ public class JJCommandVisitor extends UserCommandBaseVisitor<Command> {
 
 	@Override
 	public Command visitDayOfWeekOnly(UserCommandParser.DayOfWeekOnlyContext ctx) {
-		int dayInt = getDayOfWeekInt(ctx.dayOfWeek());
+		int dayInt = getDayOfWeekInt(ctx);
 		DayOfWeek.of(dayInt);	// check that dayInt is valid
 		LocalDate today = LocalDate.now();
 		int todayInt = today.getDayOfWeek().getValue();

--- a/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTaskTest.java
+++ b/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTaskTest.java
@@ -10,7 +10,7 @@ import java.time.LocalTime;
 import org.junit.Before;
 import org.junit.Test;
 
-public class JJParserTest {
+public class JJParserAddTaskTest {
 	JJParser parser;
 
 	@Before

--- a/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTaskTest.java
+++ b/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTaskTest.java
@@ -255,4 +255,33 @@ public class JJParserAddTaskTest {
 		        resultDateTime.toLocalDate());
 		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
 	}
+
+	@Test
+	public void testFullDateTimeMonthWord() {
+		Command result = parser.parse("Submit assignment 2 by 20 Feb 2016 5 pm");
+		assertEquals(true, result instanceof AddTaskCommand);
+		AddTaskCommand casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		LocalDateTime resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 2, 20), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(17, 00), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by 11.50 ocToBEr 15, 2016");
+		System.out.println();
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 10, 15), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(11, 50), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by july 4 12.00");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(LocalDateTime.now().getYear(), 7, 4),
+		        resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(12, 0), resultDateTime.toLocalTime());
+	}
 }

--- a/src/test/java/cs2103/v15_1j/jimjim/JJParserTest.java
+++ b/src/test/java/cs2103/v15_1j/jimjim/JJParserTest.java
@@ -197,4 +197,62 @@ public class JJParserTest {
 		assertEquals("Invalid time, please use correct 12-hour format: 13",
 				casted.getMessage());
 	}
+
+	@Test
+	public void testFullDateMonthWord() {
+		Command result = parser.parse("Submit assignment 2 by 31-May-2016");
+		assertEquals(true, result instanceof AddTaskCommand);
+		AddTaskCommand casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		LocalDateTime resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 5, 31), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by 31 DECEMBER, 2016");
+		System.out.println();
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 12, 31), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by 30 apr");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(LocalDateTime.now().getYear(), 4, 30),
+		        resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+	}
+
+	@Test
+	public void testFullDateMonthWordMonthFirst() {
+		Command result = parser.parse("Submit assignment 2 by FEB/20/2016");
+		assertEquals(true, result instanceof AddTaskCommand);
+		AddTaskCommand casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		LocalDateTime resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 2, 20), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by ocToBEr 15, 2016");
+		System.out.println();
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 10, 15), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by july 4");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(LocalDateTime.now().getYear(), 7, 4),
+		        resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+	}
 }

--- a/src/test/java/cs2103/v15_1j/jimjim/JJParserTest.java
+++ b/src/test/java/cs2103/v15_1j/jimjim/JJParserTest.java
@@ -152,4 +152,49 @@ public class JJParserTest {
 		assertEquals(true, resultDateTime.isAfter(now));
 		assertEquals(LocalTime.of(14, 00), resultDateTime.toLocalTime());
 	}
+
+	@Test
+	public void test12HourFormat() {
+		Command result = parser.parse("Go to sleep by 11 pm");
+		assertEquals(true, result instanceof AddTaskCommand);
+		AddTaskCommand casted = (AddTaskCommand) result;
+		assertEquals("Go to sleep", casted.getTask().getName());
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime resultDateTime = casted.getTask().getDateTime();
+		assertEquals(now.toLocalDate(), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 0), resultDateTime.toLocalTime());
+
+		result = parser.parse("Go to sleep by 11.45 a.m.");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Go to sleep", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(now.toLocalDate(), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(11, 45), resultDateTime.toLocalTime());
+
+		result = parser.parse("Go to sleep by 12:45 a.m.");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Go to sleep", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(now.toLocalDate(), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(0, 45), resultDateTime.toLocalTime());
+
+		result = parser.parse("Go to sleep by 12:45 pm");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Go to sleep", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(now.toLocalDate(), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(12, 45), resultDateTime.toLocalTime());
+	}
+	
+	@Test
+	public void testInvalid12HourFormat() {
+		Command result = parser.parse("Go to sleep by 13 a.m.");
+		assertEquals(true, result instanceof InvalidCommand);
+		InvalidCommand casted = (InvalidCommand) result;
+		assertEquals("Invalid time, please use correct 12-hour format: 13",
+				casted.getMessage());
+	}
 }


### PR DESCRIPTION
#### {time}
* ```{hour} am/p.m.``` e.g. ``` 11 a.m.```, ```12pm```
* ```{hour}.{minute} am/p.m.``` or ```{hour}:{minute} am/p.m.``` e.g. ```10.30 pm```

#### {date}
* {month} can also be the full English word or the first 3 letters of the month e.g. ```Dec```, ```april```

Note: ambiguous date and time expression like ```10 Jan 11``` will be treated as a date, i.e. 10th january of the year 11. To sepcify 11 o'clock of 10 January, or 10 o'clock of 11 January, use more explicit time expression e.g. ```10 a.m. Jan 11``` or ```10 Jan 11.00```
 