### PR TITLE
Parser adding event command - close #31

### DIFF
--- a/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
+++ b/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
@@ -12,7 +12,9 @@ addCmd: task BY datetime                # addTask
 task:   .+?;
 /* Note: 10 Jan 11 will be understood as 10 Jan of the year 11
  * to specify 10 January, 11 o'lock, make 11 more explicit as a
- * tim e.g. 11.00, 11 a.m., etc.
+ * time e.g. 11.00, 11 a.m., etc.
+ * to specify 10 o'clock, 11 January, make 10 more explicit as a
+ * time
  */ 
 datetime:   date        # dateOnly
         |   time        # timeOnly

--- a/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
+++ b/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
@@ -17,13 +17,12 @@ datetime:   time date   # timeThenDate
         ;
 date:   TODAY                           # today
     |   TOMORROW                        # tomorrow
-    |   dayOfWeek                       # dayOfWeekOnly
-    |   THIS dayOfWeek                  # thisDayOfWeek
-    |   NEXT dayOfWeek                  # nextDayOfWeek
+    |   DAY_OF_WEEK                     # dayOfWeekOnly
+    |   THIS DAY_OF_WEEK                # thisDayOfWeek
+    |   NEXT DAY_OF_WEEK                # nextDayOfWeek
     |   INT ('/'|'-') INT ('/'|'-') INT # fullDate
     |   INT ('/'|'-') INT               # dayMonth
     ;
-dayOfWeek:  MON | TUE | WED | THU | FRI | SAT | SUN;
 time:   INT                         # hourOnly
     |   INT ('.'|':') INT           # hourMinute
     |   INT (AM|PM)                 # hourNoon
@@ -44,14 +43,14 @@ TOMORROW: [Tt][Oo][Mm][Oo][Rr][Rr][Oo][Ww];
 THIS: [Tt][Hh][Ii][Ss];
 NEXT: [Nn][Ee][Xx][Tt];
 
-MON: [Mm][Oo][Nn]([Dd][Aa][Yy])?;
-TUE: [Tt][Uu][Ee]([Ss][Dd][Aa][Yy])?;
-WED:[Ww][Ee][Dd]([Nn][Ee][Ss][Dd][Aa][Yy])?;
-THU: [Tt][Hh][Uu]([Rr][Ss][Dd][Aa][Yy])?;
-FRI: [Ff][Rr][Ii]([Dd][Aa][Yy])?;
-SAT: [Ss][Aa][Tt]([Uu][Rr][Dd][Aa][Yy])?;
-SUN: [Ss][Uu][Nn]([Dd][Aa][Yy])?;
-
+DAY_OF_WEEK:    [Mm][Oo][Nn]([Dd][Aa][Yy])?
+            |   [Tt][Uu][Ee]([Ss][Dd][Aa][Yy])?
+            |   [Ww][Ee][Dd]([Nn][Ee][Ss][Dd][Aa][Yy])?
+            |   [Tt][Hh][Uu]([Rr][Ss][Dd][Aa][Yy])?
+            |   [Ff][Rr][Ii]([Dd][Aa][Yy])?
+            |   [Ss][Aa][Tt]([Uu][Rr][Dd][Aa][Yy])?
+            |   [Ss][Uu][Nn]([Dd][Aa][Yy])?
+            ;
 INT:[0-9]+;
 
 WORD: [a-zA-Z0-9]+ ;

--- a/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
+++ b/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
@@ -4,7 +4,7 @@ cmd:    addCmd
     ;
 
 addCmd: task BY datetime                # addTask
-    |   task date FROM time TO time     # addEventCommonDate
+    |   task ON? date FROM time TO time # addEventCommonDate
     |   task FROM datetime TO datetime  # addEvent
     |   task                            # addFloatingTask
     ;
@@ -44,6 +44,7 @@ BY:	[Bb][Yy];
 FROM: [Ff][Rr][Oo][Mm];
 TO:	[Tt][Oo];
 AT: [Aa][Tt];
+ON: [Oo][Nn];
 
 AM: [Aa].?[Mm].?;
 PM: [Pp].?[Mm].?;

--- a/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
+++ b/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
@@ -1,32 +1,34 @@
 grammar UserCommand;
 
-cmd:	addCmd
-	;
+cmd:    addCmd
+    ;
 
-addCmd: task BY datetime				# addTask
-	|	task date FROM time TO time		# addEventCommonDate
-	|	task FROM datetime TO datetime	# addEvent
-	|	task							# addFloatingTask
-	;
+addCmd: task BY datetime                # addTask
+    |   task date FROM time TO time     # addEventCommonDate
+    |   task FROM datetime TO datetime  # addEvent
+    |   task                            # addFloatingTask
+    ;
 	
-task:	.+?;
-datetime: time date	# timeThenDate
-	| date time		# dateThenTime
-	| date			# dateOnly
-	| time			# timeOnly
-	;
-date:	TODAY							# today
-	|	TOMORROW						# tomorrow
-	|	dayOfWeek						# dayOfWeekOnly
-	|	THIS dayOfWeek					# thisDayOfWeek
-	|	NEXT dayOfWeek					# nextDayOfWeek
-	|	INT ('/'|'-') INT ('/'|'-') INT	# fullDate
-	|	INT ('/'|'-') INT				# dayMonth
-	;
-dayOfWeek:	MON | TUE | WED | THU | FRI | SAT | SUN;
-time:	INT					# hourOnly
-	|	INT ('.'|':') INT	# hourMinute
-	;
+task:   .+?;
+datetime:   time date   # timeThenDate
+        |   date time   # dateThenTime
+        |   date        # dateOnly
+        |   time        # timeOnly
+        ;
+date:   TODAY                           # today
+    |   TOMORROW                        # tomorrow
+    |   dayOfWeek                       # dayOfWeekOnly
+    |   THIS dayOfWeek                  # thisDayOfWeek
+    |   NEXT dayOfWeek                  # nextDayOfWeek
+    |   INT ('/'|'-') INT ('/'|'-') INT # fullDate
+    |   INT ('/'|'-') INT               # dayMonth
+    ;
+dayOfWeek:  MON | TUE | WED | THU | FRI | SAT | SUN;
+time:   INT                         # hourOnly
+    |   INT ('.'|':') INT           # hourMinute
+    |   INT (AM|PM)                 # hourNoon
+    |   INT ('.'|':') INT (AM|PM)   # hourMinuteNoon
+    ;
 
 
 BY:	[Bb][Yy];
@@ -34,20 +36,23 @@ FROM: [Ff][Rr][Oo][Mm];
 TO:	[Tt][Oo];
 AT: [Aa][Tt];
 
+AM: [Aa].?[Mm].?;
+PM: [Pp].?[Mm].?;
+
 TODAY: [Tt][Oo][Dd][Aa][Yy];
 TOMORROW: [Tt][Oo][Mm][Oo][Rr][Rr][Oo][Ww];
 THIS: [Tt][Hh][Ii][Ss];
 NEXT: [Nn][Ee][Xx][Tt];
 
-MON:	[Mm][Oo][Nn]([Dd][Aa][Yy])?;
-TUE:	[Tt][Uu][Ee]([Ss][Dd][Aa][Yy])?;
-WED:	[Ww][Ee][Dd]([Nn][Ee][Ss][Dd][Aa][Yy])?;
-THU:	[Tt][Hh][Uu]([Rr][Ss][Dd][Aa][Yy])?;
-FRI:	[Ff][Rr][Ii]([Dd][Aa][Yy])?;
-SAT:	[Ss][Aa][Tt]([Uu][Rr][Dd][Aa][Yy])?;
-SUN:	[Ss][Uu][Nn]([Dd][Aa][Yy])?;
+MON: [Mm][Oo][Nn]([Dd][Aa][Yy])?;
+TUE: [Tt][Uu][Ee]([Ss][Dd][Aa][Yy])?;
+WED:[Ww][Ee][Dd]([Nn][Ee][Ss][Dd][Aa][Yy])?;
+THU: [Tt][Hh][Uu]([Rr][Ss][Dd][Aa][Yy])?;
+FRI: [Ff][Rr][Ii]([Dd][Aa][Yy])?;
+SAT: [Ss][Aa][Tt]([Uu][Rr][Dd][Aa][Yy])?;
+SUN: [Ss][Uu][Nn]([Dd][Aa][Yy])?;
 
-INT:	[0-9]+;
+INT:[0-9]+;
 
-WORD:	[a-zA-Z0-9]+ ;
+WORD: [a-zA-Z0-9]+ ;
 WS: [ \t\r\n]+ -> skip;

--- a/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
+++ b/src/main/antlr4/cs2103/v15_1j/jimjim/antlr4/UserCommand.g4
@@ -10,18 +10,26 @@ addCmd: task BY datetime                # addTask
     ;
 	
 task:   .+?;
-datetime:   time date   # timeThenDate
-        |   date time   # dateThenTime
-        |   date        # dateOnly
+/* Note: 10 Jan 11 will be understood as 10 Jan of the year 11
+ * to specify 10 January, 11 o'lock, make 11 more explicit as a
+ * tim e.g. 11.00, 11 a.m., etc.
+ */ 
+datetime:   date        # dateOnly
         |   time        # timeOnly
+        |   date time   # dateThenTime
+        |   time date   # timeThenDate
         ;
-date:   TODAY                           # today
-    |   TOMORROW                        # tomorrow
-    |   DAY_OF_WEEK                     # dayOfWeekOnly
-    |   THIS DAY_OF_WEEK                # thisDayOfWeek
-    |   NEXT DAY_OF_WEEK                # nextDayOfWeek
-    |   INT ('/'|'-') INT ('/'|'-') INT # fullDate
-    |   INT ('/'|'-') INT               # dayMonth
+date:   TODAY                               # today
+    |   TOMORROW                            # tomorrow
+    |   DAY_OF_WEEK                         # dayOfWeekOnly
+    |   THIS DAY_OF_WEEK                    # thisDayOfWeek
+    |   NEXT DAY_OF_WEEK                    # nextDayOfWeek
+    |   INT ('/'|'-') INT ('/'|'-') INT     # fullDate
+    |   INT ('/'|'-') INT                   # dayMonth
+    |   INT ('/'|'-'|',')? MONTH ('/'|'-'|',')? INT # fullDateWordMonth
+    |   INT ('/'|'-'|',')? MONTH                    # dayMonthWordMonth
+    |   MONTH ('/'|'-'|',')? INT ('/'|'-'|',')? INT # fullDateWordMonthMonthFirst
+    |   MONTH ('/'|'-'|',')? INT                    # dayMonthWordMonthMonthFirst
     ;
 time:   INT                         # hourOnly
     |   INT ('.'|':') INT           # hourMinute
@@ -51,6 +59,19 @@ DAY_OF_WEEK:    [Mm][Oo][Nn]([Dd][Aa][Yy])?
             |   [Ss][Aa][Tt]([Uu][Rr][Dd][Aa][Yy])?
             |   [Ss][Uu][Nn]([Dd][Aa][Yy])?
             ;
+MONTH:  [Jj][Aa][Nn]([Uu][Aa][Rr][Yy])?
+    |   [Ff][Ee][Bb]([Rr][Uu][Aa][Rr][Yy])?
+    |   [Mm][Aa][Rr]([Cc][Hh])?
+    |   [Aa][Pp][Rr]([Ii][Ll])?
+    |   [Mm][Aa][Yy]
+    |   [Jj][Uu][Nn]([Ee])?
+    |   [Jj][Uu][Ll]([Yy])?
+    |   [Aa][Uu][Gg]([Uu][Ss][Tt])?
+    |   [Ss][Ee][Pp]([Tt][Ee][Mm][Bb][Ee][Rr])?
+    |   [Oo][Cc][Tt]([Oo][Bb][Ee][Rr])?
+    |   [Nn][Oo][Vv]([Ee][Mm][Bb][Ee][Rr])?
+    |   [Dd][Ee][Cc]([Ee][Mm][Bb][Ee][Rr])?
+    ;
 INT:[0-9]+;
 
 WORD: [a-zA-Z0-9]+ ;

--- a/src/main/java/cs2103/v15_1j/jimjim/AddEventCommand.java
+++ b/src/main/java/cs2103/v15_1j/jimjim/AddEventCommand.java
@@ -1,0 +1,30 @@
+package cs2103.v15_1j.jimjim;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class AddEventCommand implements Command {
+    
+    private Event event;
+    
+    public AddEventCommand(String name, LocalDateTime start, LocalDateTime end) {
+        this.event = new Event(name, start, end);
+    }
+    
+    public Event getEvent() {
+        return this.event;
+    }
+
+    @Override
+    public String undo(List<TaskEvent> displayList, Storage storage, Searcher searcher) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String execute(List<TaskEvent> displayList, Storage storage, Searcher searcher) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/src/main/java/cs2103/v15_1j/jimjim/Event.java
+++ b/src/main/java/cs2103/v15_1j/jimjim/Event.java
@@ -1,6 +1,18 @@
 package cs2103.v15_1j.jimjim;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 public class Event extends TaskEvent {
 	public List<EventTime> dateTime;
+	
+	public Event(String name, LocalDateTime start, LocalDateTime end) {
+	    this.name = name;
+	    this.dateTime = new ArrayList<EventTime>();
+	    this.dateTime.add(new EventTime(start, end));
+    }
+	
+	public List<EventTime> getDateTime() {
+	    return this.dateTime;
+	}
 }

--- a/src/main/java/cs2103/v15_1j/jimjim/EventTime.java
+++ b/src/main/java/cs2103/v15_1j/jimjim/EventTime.java
@@ -3,7 +3,12 @@ import java.time.LocalDateTime;
 
 public class EventTime {
 
-	public LocalDateTime start;
+    public LocalDateTime start;
 	public LocalDateTime end;
+
+	public EventTime(LocalDateTime start, LocalDateTime end) {
+	    this.start = start;
+	    this.end = end;
+    }
 
 }

--- a/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
+++ b/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
@@ -1,5 +1,6 @@
 package cs2103.v15_1j.jimjim;
 
+import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -158,7 +159,41 @@ public class JJCommandVisitor extends UserCommandBaseVisitor<Command> {
 		visit(ctx.time());
 		dateTimeMap.put(ctx, LocalDateTime.of(dateMap.get(ctx.date()),
 											  timeMap.get(ctx.time())));
-		return null;	}
+		return null;
+	}
 
+    @Override
+    public Command visitHourNoon(UserCommandParser.HourNoonContext ctx) {
+        int hour = Integer.parseInt(ctx.INT().getText());
+        hour = process12Hour(hour, ctx.AM() == null);
+        timeMap.put(ctx, LocalTime.of(hour, 0));        
+        return null;
+    }
+    
+    @Override
+    public Command visitHourMinuteNoon(UserCommandParser.HourMinuteNoonContext ctx) {
+        int hour = Integer.parseInt(ctx.INT(0).getText());
+        hour = process12Hour(hour, ctx.AM() == null);
+        int minute = Integer.parseInt(ctx.INT(1).getText());
+        timeMap.put(ctx, LocalTime.of(hour, minute));        
+        return null;
+    }
+    
+    private int process12Hour(int hour, boolean isPm) {
+        if ((hour > 12) || (hour <= 0)) {
+            throw new DateTimeException(
+                    "Invalid time, please use correct 12-hour format: " + hour);
+        }
+        int offset = isPm ? 12 : 0;
+        hour += offset;
+        if (hour == 12) {   // those are corner cases
+            // 12am
+            hour = 0;
+        } else if (hour == 24) {
+            // 12pm
+            hour = 12;
+        }
+        return hour;
+    }
 
 }

--- a/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
+++ b/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import org.antlr.v4.runtime.tree.ParseTreeProperty;
+import org.antlr.v4.runtime.tree.TerminalNode;
 
 import cs2103.v15_1j.jimjim.antlr4.UserCommandBaseVisitor;
 import cs2103.v15_1j.jimjim.antlr4.UserCommandParser;
@@ -196,4 +197,55 @@ public class JJCommandVisitor extends UserCommandBaseVisitor<Command> {
         return hour;
     }
 
+	@Override
+	public Command visitFullDateWordMonth(
+	        UserCommandParser.FullDateWordMonthContext ctx) {
+		int day = Integer.parseInt(ctx.INT(0).getText());
+		int month = getMonth(ctx.MONTH());
+		int year = Integer.parseInt(ctx.INT(1).getText());
+		dateMap.put(ctx, LocalDate.of(year, month, day));
+		return null;
+    }
+
+	@Override
+	public Command visitDayMonthWordMonth(
+	        UserCommandParser.DayMonthWordMonthContext ctx) {
+		int year = LocalDate.now().getYear();
+		int month = getMonth(ctx.MONTH());
+		int day = Integer.parseInt(ctx.INT().getText());
+		dateMap.put(ctx, LocalDate.of(year, month, day));
+		return null;
+    }
+
+	@Override
+	public Command visitFullDateWordMonthMonthFirst(
+	        UserCommandParser.FullDateWordMonthMonthFirstContext ctx) {
+		int day = Integer.parseInt(ctx.INT(0).getText());
+		int month = getMonth(ctx.MONTH());
+		int year = Integer.parseInt(ctx.INT(1).getText());
+		dateMap.put(ctx, LocalDate.of(year, month, day));
+		return null;
+    }
+
+	@Override
+	public Command visitDayMonthWordMonthMonthFirst(
+	        UserCommandParser.DayMonthWordMonthMonthFirstContext ctx) {
+		int year = LocalDate.now().getYear();
+		int month = getMonth(ctx.MONTH());
+		int day = Integer.parseInt(ctx.INT().getText());
+		dateMap.put(ctx, LocalDate.of(year, month, day));
+		return null;
+    }
+	
+	private int getMonth(TerminalNode terminalNode) {
+		String month = terminalNode.getText().substring(0, 3).toLowerCase();
+		String[] months = {"", "jan", "feb", "mar", "apr", "may", "jun", "jul",
+		        "aug", "sep", "oct", "nov", "dec"};
+		for (int i=0; i<months.length; i++) {
+			if (months[i].equals(month)) {
+				return i;
+			}
+		}
+		return 0;	// shouldn't happen
+	}
 }

--- a/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
+++ b/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
@@ -87,7 +87,7 @@ public class JJCommandVisitor extends UserCommandBaseVisitor<Command> {
 		return null;
 	}
 	
-	private int getDayOfWeekInt(UserCommandParser.DayOfWeekContext ctx) {
+	private int getDayOfWeekInt(UserCommandParser.DayOfWeekOnlyContext ctx) {
 		String day = ctx.getText().substring(0, 3).toLowerCase();
 		String[] days = {"", "mon", "tue", "wed", "thu", "fri", "sat", "sun"};
 		for (int i=0; i<days.length; i++) {
@@ -100,7 +100,7 @@ public class JJCommandVisitor extends UserCommandBaseVisitor<Command> {
 
 	@Override
 	public Command visitDayOfWeekOnly(UserCommandParser.DayOfWeekOnlyContext ctx) {
-		int dayInt = getDayOfWeekInt(ctx.dayOfWeek());
+		int dayInt = getDayOfWeekInt(ctx);
 		DayOfWeek.of(dayInt);	// check that dayInt is valid
 		LocalDate today = LocalDate.now();
 		int todayInt = today.getDayOfWeek().getValue();

--- a/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
+++ b/src/main/java/cs2103/v15_1j/jimjim/JJCommandVisitor.java
@@ -248,4 +248,27 @@ public class JJCommandVisitor extends UserCommandBaseVisitor<Command> {
 		}
 		return 0;	// shouldn't happen
 	}
+
+	@Override
+	public Command visitAddEventCommonDate(
+	        UserCommandParser.AddEventCommonDateContext ctx) {
+		visit(ctx.task());
+		visit(ctx.date());
+		visit(ctx.time(0));
+		visit(ctx.time(1));
+		LocalDate date = dateMap.get(ctx.date());
+		return new AddEventCommand(stringMap.get(ctx.task()),
+								  LocalDateTime.of(date, timeMap.get(ctx.time(0))),
+								  LocalDateTime.of(date, timeMap.get(ctx.time(1))));
+    }
+
+	@Override
+	public Command visitAddEvent(UserCommandParser.AddEventContext ctx) {
+		visit(ctx.task());
+		visit(ctx.datetime(0));
+		visit(ctx.datetime(1));
+		return new AddEventCommand(stringMap.get(ctx.task()),
+								  dateTimeMap.get(ctx.datetime(0)),
+								  dateTimeMap.get(ctx.datetime(1)));
+    }
 }

--- a/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTaskTest.java
+++ b/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTaskTest.java
@@ -10,7 +10,7 @@ import java.time.LocalTime;
 import org.junit.Before;
 import org.junit.Test;
 
-public class JJParserTest {
+public class JJParserAddTaskTest {
 	JJParser parser;
 
 	@Before

--- a/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTaskTest.java
+++ b/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTaskTest.java
@@ -255,4 +255,33 @@ public class JJParserAddTaskTest {
 		        resultDateTime.toLocalDate());
 		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
 	}
+
+	@Test
+	public void testFullDateTimeMonthWord() {
+		Command result = parser.parse("Submit assignment 2 by 20 Feb 2016 5 pm");
+		assertEquals(true, result instanceof AddTaskCommand);
+		AddTaskCommand casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		LocalDateTime resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 2, 20), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(17, 00), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by 11.50 ocToBEr 15, 2016");
+		System.out.println();
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 10, 15), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(11, 50), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by july 4 12.00");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(LocalDateTime.now().getYear(), 7, 4),
+		        resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(12, 0), resultDateTime.toLocalTime());
+	}
 }

--- a/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTest.java
+++ b/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTest.java
@@ -6,6 +6,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -283,5 +284,51 @@ public class JJParserAddTest {
 		assertEquals(LocalDate.of(LocalDateTime.now().getYear(), 7, 4),
 		        resultDateTime.toLocalDate());
 		assertEquals(LocalTime.of(12, 0), resultDateTime.toLocalTime());
+	}
+
+	@Test
+	public void testEventCommonDate() {
+		Command result = parser.parse(
+		        "Group meeting on 20 Feb from 1:30 pm to 3 pm");
+		assertEquals(true, result instanceof AddEventCommand);
+		AddEventCommand casted = (AddEventCommand) result;
+		assertEquals("Group meeting", casted.getEvent().getName());
+		List<EventTime> resultDateTime = casted.getEvent().getDateTime();
+		assertEquals(1, resultDateTime.size());
+		EventTime timing = resultDateTime.get(0);
+		assertEquals(LocalDate.of(2016, 2, 20), timing.start.toLocalDate());
+		assertEquals(LocalTime.of(13, 30), timing.start.toLocalTime());
+		assertEquals(LocalDate.of(2016, 2, 20), timing.end.toLocalDate());
+		assertEquals(LocalTime.of(15, 00), timing.end.toLocalTime());
+
+		result = parser.parse(
+		        "Group meeting 20 Feb from 1:30 pm to 3 pm");
+		assertEquals(true, result instanceof AddEventCommand);
+		casted = (AddEventCommand) result;
+		assertEquals("Group meeting", casted.getEvent().getName());
+		resultDateTime = casted.getEvent().getDateTime();
+		assertEquals(1, resultDateTime.size());
+		timing = resultDateTime.get(0);
+		assertEquals(LocalDate.of(2016, 2, 20), timing.start.toLocalDate());
+		assertEquals(LocalTime.of(13, 30), timing.start.toLocalTime());
+		assertEquals(LocalDate.of(2016, 2, 20), timing.end.toLocalDate());
+		assertEquals(LocalTime.of(15, 00), timing.end.toLocalTime());
+	}
+
+	@Test
+	public void testEventDiffDate() {
+		Command result = parser.parse(
+		        "Camping with friends from June 1 2016 9:00 am to June 3 5:00 pm");
+		assertEquals(true, result instanceof AddEventCommand);
+		AddEventCommand casted = (AddEventCommand) result;
+		assertEquals("Camping with friends", casted.getEvent().getName());
+		List<EventTime> resultDateTime = casted.getEvent().getDateTime();
+		assertEquals(1, resultDateTime.size());
+		EventTime timing = resultDateTime.get(0);
+		assertEquals(LocalDate.of(2016, 6, 1), timing.start.toLocalDate());
+		assertEquals(LocalTime.of(9, 00), timing.start.toLocalTime());
+		assertEquals(LocalDate.of(2016, 6, 3), timing.end.toLocalDate());
+		assertEquals(LocalTime.of(17, 00), timing.end.toLocalTime());
+
 	}
 }

--- a/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTest.java
+++ b/src/test/java/cs2103/v15_1j/jimjim/JJParserAddTest.java
@@ -10,7 +10,7 @@ import java.time.LocalTime;
 import org.junit.Before;
 import org.junit.Test;
 
-public class JJParserAddTaskTest {
+public class JJParserAddTest {
 	JJParser parser;
 
 	@Before

--- a/src/test/java/cs2103/v15_1j/jimjim/JJParserTest.java
+++ b/src/test/java/cs2103/v15_1j/jimjim/JJParserTest.java
@@ -197,4 +197,62 @@ public class JJParserTest {
 		assertEquals("Invalid time, please use correct 12-hour format: 13",
 				casted.getMessage());
 	}
+
+	@Test
+	public void testFullDateMonthWord() {
+		Command result = parser.parse("Submit assignment 2 by 31-May-2016");
+		assertEquals(true, result instanceof AddTaskCommand);
+		AddTaskCommand casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		LocalDateTime resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 5, 31), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by 31 DECEMBER, 2016");
+		System.out.println();
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 12, 31), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by 30 apr");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(LocalDateTime.now().getYear(), 4, 30),
+		        resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+	}
+
+	@Test
+	public void testFullDateMonthWordMonthFirst() {
+		Command result = parser.parse("Submit assignment 2 by FEB/20/2016");
+		assertEquals(true, result instanceof AddTaskCommand);
+		AddTaskCommand casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		LocalDateTime resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 2, 20), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by ocToBEr 15, 2016");
+		System.out.println();
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(2016, 10, 15), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+
+		result = parser.parse("Submit assignment 2 by july 4");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Submit assignment 2", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(LocalDate.of(LocalDateTime.now().getYear(), 7, 4),
+		        resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 59), resultDateTime.toLocalTime());
+	}
 }

--- a/src/test/java/cs2103/v15_1j/jimjim/JJParserTest.java
+++ b/src/test/java/cs2103/v15_1j/jimjim/JJParserTest.java
@@ -152,4 +152,49 @@ public class JJParserTest {
 		assertEquals(true, resultDateTime.isAfter(now));
 		assertEquals(LocalTime.of(14, 00), resultDateTime.toLocalTime());
 	}
+
+	@Test
+	public void test12HourFormat() {
+		Command result = parser.parse("Go to sleep by 11 pm");
+		assertEquals(true, result instanceof AddTaskCommand);
+		AddTaskCommand casted = (AddTaskCommand) result;
+		assertEquals("Go to sleep", casted.getTask().getName());
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime resultDateTime = casted.getTask().getDateTime();
+		assertEquals(now.toLocalDate(), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(23, 0), resultDateTime.toLocalTime());
+
+		result = parser.parse("Go to sleep by 11.45 a.m.");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Go to sleep", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(now.toLocalDate(), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(11, 45), resultDateTime.toLocalTime());
+
+		result = parser.parse("Go to sleep by 12:45 a.m.");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Go to sleep", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(now.toLocalDate(), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(0, 45), resultDateTime.toLocalTime());
+
+		result = parser.parse("Go to sleep by 12:45 pm");
+		assertEquals(true, result instanceof AddTaskCommand);
+		casted = (AddTaskCommand) result;
+		assertEquals("Go to sleep", casted.getTask().getName());
+		resultDateTime = casted.getTask().getDateTime();
+		assertEquals(now.toLocalDate(), resultDateTime.toLocalDate());
+		assertEquals(LocalTime.of(12, 45), resultDateTime.toLocalTime());
+	}
+	
+	@Test
+	public void testInvalid12HourFormat() {
+		Command result = parser.parse("Go to sleep by 13 a.m.");
+		assertEquals(true, result instanceof InvalidCommand);
+		InvalidCommand casted = (InvalidCommand) result;
+		assertEquals("Invalid time, please use correct 12-hour format: 13",
+				casted.getMessage());
+	}
 }


### PR DESCRIPTION
Note: please review pr #46 before this one. This pr add the following syntax that the parser can understand:
* ```{name} (on) {date} from {time} to {time}``` create a new event on the same date, with the specified timing. Note that the word ```on``` is optional, hence it's put inside a bracket.
* ```{name} from {date} {time} to {date} {time}``` create a new event on potentially different date. Note that instead of writing ```{date}``` before ```{time}```, the other order is also allowed.